### PR TITLE
Added shimmer layout for RecyclerViews

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,10 +10,30 @@
         <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/drawable/profile_bg.xml" value="0.1615" />
         <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_devs.xml" value="0.12158054711246201" />
         <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_devs_test.xml" value="0.136" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_forgot_pass.xml" value="0.22644927536231885" />
         <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_library.xml" value="0.22644927536231885" />
-        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_main.xml" value="0.12158054711246201" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_login.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_main.xml" value="0.264" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_meeting_filter.xml" value="0.12158054711246201" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_meeting_view_detail.xml" value="0.12158054711246201" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_no_internet.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_register.xml" value="0.12158054711246201" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_splash.xml" value="0.12158054711246201" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_support.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_user_profile.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/dev_news_item.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/dialog_bottom_navigation.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/dialog_new_user_meeting.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/dialog_progress.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/header_layout.xml" value="0.12158054711246201" />
         <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/list_item.xml" value="0.2" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/meeting_item.xml" value="0.22644927536231885" />
         <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/shimmer_item.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/shimmer_item_meeting.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/shimmer_item_support.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/user_meeting_list_shimmer.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/layout/users_meeting_list_horizonal.xml" value="0.22644927536231885" />
+        <entry key="..\:/Users/Aayush/AndroidStudioProjects/Meetly/app/src/main/res/menu/drawer_menu.xml" value="0.25" />
         <entry key="..\:/Users/Garuda/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_login.xml" value="0.2" />
         <entry key="..\:/Users/Garuda/AndroidStudioProjects/Meetly/app/src/main/res/layout/activity_main.xml" value="0.215625" />
         <entry key="..\:/Users/priyanshu borole/AndroidOtherProj/Meetly/app/src/main/res/drawable/ic_github.xml" value="0.1" />

--- a/app/src/main/java/com/vs/meetly/MainActivity.kt
+++ b/app/src/main/java/com/vs/meetly/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.view.GravityCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -54,6 +55,7 @@ import java.util.*
 class MainActivity : AppCompatActivity(), IMeetingRVAdapter {
 
     lateinit var actionBarDrawerToggle: ActionBarDrawerToggle
+    lateinit var shimmerframelayout: ShimmerFrameLayout
 
     private lateinit var auth: FirebaseAuth
 
@@ -80,11 +82,12 @@ class MainActivity : AppCompatActivity(), IMeetingRVAdapter {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        shimmerframelayout= findViewById(R.id.shimmer_meeting)
+        shimmerframelayout.startShimmer()
         auth = FirebaseAuth.getInstance()
 
         firestore = FirebaseFirestore.getInstance()
 
-        mainPreloader.visibility = View.VISIBLE
         setUpViews()
         setUpFireStore()
         setUpRecyclerView()
@@ -200,11 +203,13 @@ class MainActivity : AppCompatActivity(), IMeetingRVAdapter {
         adapter = MeetingAdapter(this, tempMeetingList, this)
         meetingRecyclerview.layoutManager = LinearLayoutManager(this)
         meetingRecyclerview.adapter = adapter
+        shimmerframelayout.stopShimmer()
+        shimmerframelayout.visibility = View.GONE
+        meetingRecyclerview.visibility = View.VISIBLE
     }
 
     private fun loadImage(imageUrl: String) {
         Glide.with(this).load(imageUrl).circleCrop().into(header_image)
-        mainPreloader.visibility = View.GONE
     }
 
     private fun setUpViews() {

--- a/app/src/main/java/com/vs/meetly/MeetingFilter.kt
+++ b/app/src/main/java/com/vs/meetly/MeetingFilter.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -24,6 +25,7 @@ import kotlinx.coroutines.tasks.await
 class MeetingFilter : AppCompatActivity(), IMeetingRVAdapter {
 
     lateinit var adapter: MeetingAdapter
+    lateinit var shimmerlayout:ShimmerFrameLayout
 
     private var meetingList = mutableListOf<Meeting>()
 
@@ -38,7 +40,8 @@ class MeetingFilter : AppCompatActivity(), IMeetingRVAdapter {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_meeting_filter)
-
+        shimmerlayout = findViewById(R.id.shimmer_filter_meeting)
+        shimmerlayout.startShimmer()
         auth = FirebaseAuth.getInstance()
 
          DATE = intent.getStringExtra("DATE").toString()
@@ -93,6 +96,9 @@ class MeetingFilter : AppCompatActivity(), IMeetingRVAdapter {
         adapter = MeetingAdapter(this, meetingList, this)
         meetingFilterRecyclerView.layoutManager = LinearLayoutManager(this)
         meetingFilterRecyclerView.adapter = adapter
+        shimmerlayout.stopShimmer()
+        shimmerlayout.visibility = View.GONE
+        meetingFilterRecyclerView.visibility = View.VISIBLE
     }
 
     override fun onItemClicked(meeting: Meeting) {

--- a/app/src/main/java/com/vs/meetly/MeetingViewDetail.kt
+++ b/app/src/main/java/com/vs/meetly/MeetingViewDetail.kt
@@ -18,6 +18,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseAuth
@@ -51,6 +52,7 @@ class MeetingViewDetail : AppCompatActivity(), IVdeleteUser {
     }
 
     private lateinit var auth: FirebaseAuth
+    private lateinit var shimmerlayout:ShimmerFrameLayout
 
     private lateinit var localMeeting: Meeting
 
@@ -65,8 +67,8 @@ class MeetingViewDetail : AppCompatActivity(), IVdeleteUser {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_meeting_view_detail)
-
-        meetingViewDetailPreloader.visibility = View.VISIBLE
+        shimmerlayout = findViewById(R.id.shimmer_meeting_view)
+        shimmerlayout.startShimmer()
 
         currentMeetingId = intent.getStringExtra("meeting_document_id").toString()
 
@@ -110,6 +112,9 @@ class MeetingViewDetail : AppCompatActivity(), IVdeleteUser {
         meeting_info_recycle_view.layoutManager = mLayoutManager
         meeting_info_recycle_view.itemAnimator = DefaultItemAnimator()
         meeting_info_recycle_view.adapter = adapter
+        shimmerlayout.stopShimmer()
+        shimmerlayout.visibility=View.GONE
+        meeting_info_recycle_view.visibility=View.VISIBLE
     }
 
 
@@ -156,7 +161,7 @@ class MeetingViewDetail : AppCompatActivity(), IVdeleteUser {
 
         registerForBroadcastMessages()
 
-        meetingViewDetailPreloader.visibility = View.GONE
+
 
     }
 

--- a/app/src/main/java/com/vs/meetly/SupportActivity.kt
+++ b/app/src/main/java/com/vs/meetly/SupportActivity.kt
@@ -5,14 +5,18 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.firebase.firestore.FirebaseFirestore
 import com.vs.meetly.adapters.SupportAdapter
 import com.vs.meetly.modals.SupportSection
+import kotlinx.android.synthetic.main.activity_devs.*
 import kotlinx.android.synthetic.main.activity_support.*
+import kotlinx.android.synthetic.main.activity_support.topAppBar
 
 class SupportActivity : AppCompatActivity() {
 
     lateinit var adapter: SupportAdapter
+    lateinit var shimmerframelayout:ShimmerFrameLayout
 
     private var supportList = mutableListOf<SupportSection>()
 
@@ -21,8 +25,9 @@ class SupportActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_support)
+        shimmerframelayout = findViewById(R.id.shimmer_support)
+        shimmerframelayout.startShimmer()
 
-        supportPreloader.visibility = View.VISIBLE
 
         setUpRecycleView()
 
@@ -77,10 +82,13 @@ class SupportActivity : AppCompatActivity() {
             }
             supportList.clear()
             supportList.addAll(value.toObjects(SupportSection::class.java))
+            shimmerframelayout.stopShimmer()
+            shimmerframelayout.visibility=View.GONE
+            SupportRecyclerView.visibility=View.VISIBLE
             adapter = SupportAdapter(this, supportList)
             SupportRecyclerView.layoutManager = LinearLayoutManager(this)
             SupportRecyclerView.adapter = adapter
-            supportPreloader.visibility = View.GONE
+
         }
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,10 +30,29 @@
                 app:title="@string/app_name" />
         </com.google.android.material.appbar.AppBarLayout>
 
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:layout_width="match_parent"
+            android:id="@+id/shimmer_meeting"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/appBarLayout">
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <include layout="@layout/shimmer_item_meeting"/>
+                <include layout="@layout/shimmer_item_meeting"/>
+                <include layout="@layout/shimmer_item_meeting"/>
+
+            </LinearLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/meetingRecyclerview"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -64,26 +83,6 @@
             app:lottie_autoPlay="true"
             app:lottie_loop="true"
             app:lottie_rawRes="@raw/no_data2" />
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/mainPreloader"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            app:cardCornerRadius="20dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <com.airbnb.lottie.LottieAnimationView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center"
-                app:lottie_autoPlay="true"
-                app:lottie_loop="true"
-                app:lottie_rawRes="@raw/loaderanim1" />
-        </androidx.cardview.widget.CardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_meeting_filter.xml
+++ b/app/src/main/res/layout/activity_meeting_filter.xml
@@ -24,10 +24,29 @@
             app:title="Filter Meetings" />
     </com.google.android.material.appbar.AppBarLayout>
 
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:layout_width="match_parent"
+        android:id="@+id/shimmer_filter_meeting"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/filterAppbar">
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <include layout="@layout/shimmer_item_meeting"/>
+            <include layout="@layout/shimmer_item_meeting"/>
+            <include layout="@layout/shimmer_item_meeting"/>
+
+        </LinearLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/meetingFilterRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/activity_meeting_view_detail.xml
+++ b/app/src/main/res/layout/activity_meeting_view_detail.xml
@@ -339,6 +339,22 @@
             android:text="@string/add_more" />
     </LinearLayout>
 
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:layout_width="match_parent"
+        android:id="@+id/shimmer_meeting_view"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/md_for_space">
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <include layout="@layout/user_meeting_list_shimmer"/>
+            <include layout="@layout/user_meeting_list_shimmer"/>
+
+        </LinearLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/meeting_info_recycle_view"
         android:layout_width="match_parent"
@@ -346,6 +362,7 @@
         android:layout_gravity="center"
         android:isScrollContainer="true"
         android:orientation="horizontal"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
@@ -364,25 +381,7 @@
         app:layout_constraintRight_toRightOf="parent"
         android:visibility="gone"/>
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/meetingViewDetailPreloader"
-        android:layout_width="100dp"
-        android:layout_height="100dp"
-        app:cardCornerRadius="20dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
 
-        <com.airbnb.lottie.LottieAnimationView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            app:lottie_autoPlay="true"
-            app:lottie_loop="true"
-            app:lottie_rawRes="@raw/loaderanim1" />
-    </androidx.cardview.widget.CardView>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_support.xml
+++ b/app/src/main/res/layout/activity_support.xml
@@ -29,42 +29,36 @@
                 app:title="Developer Support" />
         </com.google.android.material.appbar.AppBarLayout>
 
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:layout_width="match_parent"
+            android:id="@+id/shimmer_support"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/filterAppbar">
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <include layout="@layout/shimmer_item_support"/>
+                <include layout="@layout/shimmer_item_support"/>
+                <include layout="@layout/shimmer_item_support"/>
+                <include layout="@layout/shimmer_item_support"/>
+            </LinearLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/SupportRecyclerView"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@id/filterAppbar"
             tools:listitem="@layout/dev_news_item" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/supportPreloader"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone">
 
-            <androidx.cardview.widget.CardView
-                android:layout_width="100dp"
-                android:layout_height="100dp"
-                app:cardCornerRadius="20dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <com.airbnb.lottie.LottieAnimationView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    app:lottie_autoPlay="true"
-                    app:lottie_loop="true"
-                    app:lottie_rawRes="@raw/loaderanim1" />
-
-            </androidx.cardview.widget.CardView>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/shimmer_item_meeting.xml
+++ b/app/src/main/res/layout/shimmer_item_meeting.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cardViewMeeting"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="18dp"
+    android:background="?attr/colorSurface"
+    android:clickable="true"
+    android:focusable="true"
+    app:cardCornerRadius="15dp"
+    android:elevation="10dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="170dp">
+
+
+        <ImageView
+            android:id="@+id/imageView2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:contentDescription="@string/select_time"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/meetingdate"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_baseline_access_time_24"
+            app:tint="?attr/colorOnSurface" />
+
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_marginStart="30dp"
+            android:contentDescription="@string/display_calender"
+            android:src="@drawable/ic_baseline_calendar_today_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/linearLayout"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/meetingdate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:fontFamily="@font/poppins"
+            android:text=" "
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/imageView"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/textContent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/righteous"
+            android:text="@string/app_name"
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toTopOf="@+id/meetingdate"
+            app:layout_constraintStart_toEndOf="@+id/linearLayout"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/meetingtime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginStart="10dp"
+            android:fontFamily="@font/poppins"
+            android:text=" "
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/imageView2"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/deleteMeeting"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:layout_marginBottom="20dp"
+
+            android:contentDescription="@string/delete_meeting_icon"
+            android:src="@android:drawable/ic_menu_delete"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="@color/black" />
+
+        <LinearLayout
+            android:id="@+id/linearLayout"
+            android:layout_width="15dp"
+            android:layout_height="match_parent"
+            android:background="#3C0E0E"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1.0" />
+
+        <ImageView
+            android:id="@+id/imageView4"
+            android:layout_width="40dp"
+            android:layout_height="30dp"
+            android:layout_marginBottom="16dp"
+            android:layout_marginStart="30dp"
+            android:src="@drawable/ic_baseline_group_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/linearLayout"
+            app:tint="@color/secondary_dark"
+            android:contentDescription="@string/app_name" />
+
+        <TextView
+            android:id="@+id/main_attende_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginBottom="18dp"
+            android:fontFamily="@font/catamaran"
+            android:text=" "
+            android:textColor="@color/secondary_dark"
+            android:textSize="17sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/imageView4" />
+
+        <TextView
+            android:id="@+id/main_attende_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/catamaran"
+            android:layout_margin="10dp"
+            app:layout_constraintBaseline_toBaselineOf="@id/main_attende_head"
+            android:text=" "
+            android:textColor="@color/secondary_dark"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/main_attende_head" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/shimmer_item_support.xml
+++ b/app/src/main/res/layout/shimmer_item_support.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/cardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="18dp"
+    android:backgroundTint="?attr/colorSurface"
+    app:cardCornerRadius="15dp"
+    app:cardElevation="3dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+
+        <TextView
+            android:id="@+id/textUsername"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/catamaran_medium"
+
+            android:textColor="@color/primary_blue"
+            android:textSize="20sp"
+            app:layout_constraintStart_toStartOf="@+id/guideline2"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/textDes"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:fontFamily="@font/catamaran_medium"
+
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="16sp"
+            app:autoSizeTextType="none"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/imageView3" />
+
+        <TextView
+            android:id="@+id/lastTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginStart="5dp"
+            android:layout_marginTop="5dp"
+            android:fontFamily="@font/catamaran"
+
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/guideline2"
+            app:layout_constraintTop_toBottomOf="@+id/textUsername" />
+
+        <ImageView
+            android:id="@+id/imageView3"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="20dp"
+            android:contentDescription="@string/user_avatar"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@tools:sample/avatars" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.25" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/user_meeting_list_shimmer.xml
+++ b/app/src/main/res/layout/user_meeting_list_shimmer.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_centerHorizontal="true"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginLeft="40dp"
+    android:layout_marginTop="5dp"
+    android:layout_marginRight="40dp"
+    android:layout_marginBottom="5dp"
+    android:backgroundTint="#dddddd"
+    android:orientation="horizontal"
+    app:cardCornerRadius="10dp"
+    app:cardElevation="5dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginBottom="5dp">
+
+        <ImageView
+            android:id="@+id/users_list_meeting_image"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_margin="5dp"
+            android:contentDescription="@string/user_meeting_list_image"
+            android:src="@drawable/light_logo"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/users_list_meeting_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/catamaran"
+            android:text=" "
+            android:textColor="@color/design_default_color_on_primary"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@id/users_list_meeting_image"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/user_list_meeting_delete"
+            android:layout_width="50dp"
+            android:layout_height="30dp"
+            android:layout_marginBottom="4dp"
+            android:padding="10dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/ic_baseline_close_24"
+            app:layout_constraintBottom_toTopOf="@id/users_list_meeting_email"
+            app:layout_constraintRight_toRightOf="parent"
+            app:tint="@color/design_default_color_on_primary" />
+
+        <TextView
+            android:id="@+id/users_list_meeting_email"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/catamaran"
+            android:text=" "
+            android:textColor="@color/grey_200"
+            android:textSize="14sp"
+            app:layout_constraintStart_toEndOf="@id/users_list_meeting_image"
+            app:layout_constraintTop_toBottomOf="@id/users_list_meeting_name" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
<hr>

## Description 📜

- Added Shimmer Layout in four activities to fill up the gap when recycler view is loading.
- Four activities are - MainActivity , MeetingFilter , MeetingViewDetail, and SupportActivity.

Fixes #31

<hr>

## Domain of Contribution 📊

<!----Please delete the hashtag from your domain----->

- [ ] Documentation
- [x] Android (Kotlin)
- [ ] Backend (Express)

<hr>

## Checklist ✅

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [Code of Conduct](https://github.com/vigneshshettyin/Meetly/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generates no new warnings.
- [x] I'm GSSOC'22 contributor

<hr>

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

## Screenshots / Gif 📸

The shimmer layout is not clearly visible here as the recycler view in these cases gets populated very quickly as there is no API involvement here.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/77546902/161118420-6a132814-1c57-4b66-bac6-8e768d83098b.gif)

<hr>
